### PR TITLE
Include amsmath package

### DIFF
--- a/python/tm_quiver.py
+++ b/python/tm_quiver.py
@@ -47,6 +47,7 @@ class Quiver(LaTeX):
 
         self.pre_code = """
 \\documentclass[tikz]{standalone}
+\\usepackage{amsmath}
 \\input "%s/latex/quiver.sty"
 \\begin{document}
 """ % (the_plugin_path)


### PR DESCRIPTION
It is necessary for macros such as `\text`.